### PR TITLE
Add item scaling independent of block scaling for signal parts

### DIFF
--- a/src/main/java/net/landofrails/landofsignals/blocks/BlockSignalPart.java
+++ b/src/main/java/net/landofrails/landofsignals/blocks/BlockSignalPart.java
@@ -45,9 +45,21 @@ public class BlockSignalPart extends BlockTypeEntity {
         return new Vec3d(translation[0], translation[1], translation[2]);
     }
 
+    public Vec3d getItemTranslation(String uncheckedId) {
+        String id = checkIfMissing(uncheckedId);
+        float[] translation = signalParts.get(id).getItemTranslation();
+        return new Vec3d(translation[0], translation[1], translation[2]);
+    }
+
     public Vec3d getScaling(String uncheckedId) {
         String id = checkIfMissing(uncheckedId);
         float[] scaling = signalParts.get(id).getScaling();
+        return new Vec3d(scaling[0], scaling[1], scaling[2]);
+    }
+
+    public Vec3d getItemScaling(String uncheckedId) {
+        String id = checkIfMissing(uncheckedId);
+        float[] scaling = signalParts.get(id).getItemScaling();
         return new Vec3d(scaling[0], scaling[1], scaling[2]);
     }
 
@@ -57,12 +69,6 @@ public class BlockSignalPart extends BlockTypeEntity {
 
     public String getId(String uncheckedId) {
         return signalParts.get(checkIfMissing(uncheckedId)).getId();
-    }
-
-    public Vec3d getItemTranslation(String uncheckedId) {
-        String id = checkIfMissing(uncheckedId);
-        float[] translation = signalParts.get(id).getItemTranslation();
-        return new Vec3d(translation[0], translation[1], translation[2]);
     }
 
     public String getName(String uncheckedId) {

--- a/src/main/java/net/landofrails/landofsignals/blocks/BlockSignalPartAnimated.java
+++ b/src/main/java/net/landofrails/landofsignals/blocks/BlockSignalPartAnimated.java
@@ -46,9 +46,21 @@ public class BlockSignalPartAnimated extends BlockTypeEntity {
         return new Vec3d(translation[0], translation[1], translation[2]);
     }
 
+    public Vec3d getItemTranslation(String uncheckedId) {
+        String id = checkIfMissing(uncheckedId);
+        float[] translation = signalParts.get(id).getItemTranslation();
+        return new Vec3d(translation[0], translation[1], translation[2]);
+    }
+
     public Vec3d getScaling(String uncheckedId) {
         String id = checkIfMissing(uncheckedId);
         float[] scaling = signalParts.get(id).getScaling();
+        return new Vec3d(scaling[0], scaling[1], scaling[2]);
+    }
+
+    public Vec3d getItemScaling(String uncheckedId) {
+        String id = checkIfMissing(uncheckedId);
+        float[] scaling = signalParts.get(id).getItemScaling();
         return new Vec3d(scaling[0], scaling[1], scaling[2]);
     }
 
@@ -58,12 +70,6 @@ public class BlockSignalPartAnimated extends BlockTypeEntity {
 
     public String getId(String uncheckedId) {
         return signalParts.get(checkIfMissing(uncheckedId)).getId();
-    }
-
-    public Vec3d getItemTranslation(String uncheckedId) {
-        String id = checkIfMissing(uncheckedId);
-        float[] translation = signalParts.get(id).getItemTranslation();
-        return new Vec3d(translation[0], translation[1], translation[2]);
     }
 
     public String getName(String uncheckedId) {

--- a/src/main/java/net/landofrails/landofsignals/render/item/ItemSignalPartAnimatedRender.java
+++ b/src/main/java/net/landofrails/landofsignals/render/item/ItemSignalPartAnimatedRender.java
@@ -60,10 +60,10 @@ public class ItemSignalPartAnimatedRender {
             } else
                 textureName = null;
             Vec3d translate = LOSBlocks.BLOCK_SIGNAL_PART_ANIMATED.getItemTranslation(itemId);
-            float scale = (float) LOSBlocks.BLOCK_SIGNAL_PART_ANIMATED.getScaling(itemId).x;
+            Vec3d scale = LOSBlocks.BLOCK_SIGNAL_PART_ANIMATED.getItemScaling(itemId);
             try (OpenGL.With ignored = OpenGL.matrix(); OpenGL.With ignored1 = renderer.bindTexture(textureName)) {
                 GL11.glTranslated(translate.x, translate.y, translate.z);
-                GL11.glScaled(scale, scale, scale);
+                GL11.glScaled(scale.x, scale.y, scale.z);
                 renderer.draw();
             }
         });

--- a/src/main/java/net/landofrails/landofsignals/render/item/ItemSignalPartRender.java
+++ b/src/main/java/net/landofrails/landofsignals/render/item/ItemSignalPartRender.java
@@ -59,10 +59,10 @@ public class ItemSignalPartRender {
             else
                 textureName = null;
             Vec3d translate = LOSBlocks.BLOCK_SIGNAL_PART.getItemTranslation(itemId);
-            float scale = (float) LOSBlocks.BLOCK_SIGNAL_PART.getScaling(itemId).x;
+            Vec3d scale = LOSBlocks.BLOCK_SIGNAL_PART.getItemScaling(itemId);
             try (OpenGL.With ignored = OpenGL.matrix(); OpenGL.With ignored1 = renderer.bindTexture(textureName)) {
                 GL11.glTranslated(translate.x, translate.y, translate.z);
-                GL11.glScaled(scale, scale, scale);
+                GL11.glScaled(scale.x, scale.y, scale.z);
                 renderer.draw();
             }
         });

--- a/src/main/java/net/landofrails/landofsignals/utils/contentpacks/ContentPackSignalPart.java
+++ b/src/main/java/net/landofrails/landofsignals/utils/contentpacks/ContentPackSignalPart.java
@@ -18,10 +18,22 @@ public class ContentPackSignalPart {
     private float[] translation;
     private float[] itemTranslation;
     private float[] scaling;
+    private float[] itemScaling;
 
     private List<String> states;
 
     private Map<String, List<ContentPackAnimation>> animations;
+
+    public ContentPackSignalPart(String id, String name, String model, float[] translation, float[] itemTranslation, float[] scaling, float[] itemScaling, List<String> states) {
+        this.id = id;
+        this.name = name;
+        this.model = model;
+        this.translation = translation;
+        this.itemTranslation = itemTranslation;
+        this.scaling = scaling;
+        this.itemScaling = itemScaling;
+        this.states = states;
+    }
 
     public ContentPackSignalPart(String id, String name, String model, float[] translation, float[] itemTranslation, float[] scaling, List<String> states) {
         this.id = id;
@@ -30,7 +42,20 @@ public class ContentPackSignalPart {
         this.translation = translation;
         this.itemTranslation = itemTranslation;
         this.scaling = scaling;
+        this.itemScaling = scaling;
         this.states = states;
+    }
+
+    public ContentPackSignalPart(String id, String name, String model, float[] translation, float[] itemTranslation, float[] scaling, float[] itemScaling, List<String> states, Map<String, List<ContentPackAnimation>> animations) {
+        this.id = id;
+        this.name = name;
+        this.model = model;
+        this.translation = translation;
+        this.itemTranslation = itemTranslation;
+        this.scaling = scaling;
+        this.itemScaling = itemScaling;
+        this.states = states;
+        this.animations = animations;
     }
 
     public ContentPackSignalPart(String id, String name, String model, float[] translation, float[] itemTranslation, float[] scaling, List<String> states, Map<String, List<ContentPackAnimation>> animations) {
@@ -40,6 +65,7 @@ public class ContentPackSignalPart {
         this.translation = translation;
         this.itemTranslation = itemTranslation;
         this.scaling = scaling;
+        this.itemScaling = scaling;
         this.states = states;
         this.animations = animations;
     }
@@ -90,6 +116,14 @@ public class ContentPackSignalPart {
 
     public void setScaling(float[] scaling) {
         this.scaling = scaling;
+    }
+
+    public float[] getItemScaling() {
+        return itemScaling;
+    }
+
+    public void setItemScaling(float[] itemScaling) {
+        this.itemScaling = itemScaling;
     }
 
     public List<String> getStates() {


### PR DESCRIPTION
As discussed in discord:
Signal items are offered to the user in a GUI showing all signals in a grid. The problem: Scaling of these items is coupled to the scaling of the corresponding block (which can be set in the JSON config). This pull request adds a separate scaling for the item so it can be scaled to fit into the item grid.

The changes are similar to getItemTranslation() which already has this different handling for blocks and items. I didn't get gradle to run on my maschine yet, so the changes are untested and I might have missed something.

Also, as I didn't want to modify all default signals in LOSBlocks.java, I just added two new constructors so the itemScaling is optional. I hope that this way old signal packs with only the default scaling still work, but you might want to test that.

Happy reviewing ;-)