### PR TITLE
Fix/Manipulator crashes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,5 @@
+# Sets default memory used for gradle commands. Can be overridden by user or command line properties.
+# This is required to provide enough memory for the Minecraft decompilation process.
+org.gradle.jvmargs=-Xmx3G
+# Forge why you so broken???
+org.gradle.daemon=false

--- a/src/main/java/net/landofrails/landofsignals/LandOfSignals.java
+++ b/src/main/java/net/landofrails/landofsignals/LandOfSignals.java
@@ -21,9 +21,6 @@ import net.landofrails.landofsignals.render.item.*;
 import net.landofrails.landofsignals.tile.*;
 import net.landofrails.stellwand.Stellwand;
 
-import java.lang.reflect.Method;
-import java.util.Optional;
-
 public class LandOfSignals extends ModCore.Mod {
     @SuppressWarnings({"java:S1845"})
     public static final String MODID = "landofsignals";
@@ -44,8 +41,7 @@ public class LandOfSignals extends ModCore.Mod {
 
         if (event == ModEvent.CONSTRUCT) {
             ModCore.Mod.info("Thanks for using LandOfSignals. Starting common construct now...");
-            final Optional<String> mcVersion = getMCVersion();
-            ModCore.Mod.info("Detected MC Version: " + mcVersion.orElse("Failed to receive"));
+            ModCore.Mod.info("Detected MC Version: " + ModCore.semanticVersion());
 
             ContentPackHandler.init();
 
@@ -131,23 +127,6 @@ public class LandOfSignals extends ModCore.Mod {
             default:
                 break;
         }
-    }
-
-    public Optional<String> getMCVersion() {
-        try {
-            Class<?> loader = Class.forName("net.minecraftforge.fml.common.Loader");
-            Method instanceMethod = loader.getMethod("instance");
-            Object loaderInstance = instanceMethod.invoke(null);
-            Method getMCVersionString = loader.getMethod("getMCVersionString");
-            String version = (String) getMCVersionString.invoke(loaderInstance);
-
-            return Optional.ofNullable(version);
-
-        } catch (Exception e) {
-
-            return Optional.empty();
-        }
-
     }
 
     @Override

--- a/src/main/java/net/landofrails/landofsignals/gui/GuiManipulator.java
+++ b/src/main/java/net/landofrails/landofsignals/gui/GuiManipulator.java
@@ -423,8 +423,8 @@ public class GuiManipulator implements IScreen {
 
     private void renewSlider(IScreenBuilder screen){
         if(rotationSlider != null){
-            rotationSlider.setVisible(false);
-            rotationSlider = null;
+            rotationSlider.setValue(rotation);
+            return;
         }
         rotationSlider = new Slider(screen, screen.getWidth() / 2 - 200, 100, GuiText.LABEL_ROTATIONSLIDER + ": ", 0, 360, rotation, false) {
             @Override

--- a/src/main/java/net/landofrails/landofsignals/gui/GuiManipulator.java
+++ b/src/main/java/net/landofrails/landofsignals/gui/GuiManipulator.java
@@ -147,7 +147,14 @@ public class GuiManipulator implements IScreen {
             }
         };
 
-        renewSlider(screen);
+        rotationSlider = new Slider(screen, screen.getWidth() / 2 - 200, 100, GuiText.LABEL_ROTATIONSLIDER + ": ", 0, 360, rotation, false) {
+            @Override
+            public void onSlider() {
+                rotation = rotationSlider.getValueInt();
+                setText(GuiText.LABEL_ROTATIONSLIDER + ": " + rotation);
+                updateClientBlock();
+            }
+        };
         rotationSubtraction = new Button(screen,screen.getWidth() / 2 - 220, 100, 20, 20, "-") {
             @Override
             public void onClick(Player.Hand hand) {
@@ -422,17 +429,8 @@ public class GuiManipulator implements IScreen {
     }
 
     private void renewSlider(IScreenBuilder screen){
-        if(rotationSlider != null){
-            rotationSlider.setValue(rotation);
-            return;
-        }
-        rotationSlider = new Slider(screen, screen.getWidth() / 2 - 200, 100, GuiText.LABEL_ROTATIONSLIDER + ": ", 0, 360, rotation, false) {
-            @Override
-            public void onSlider() {
-                rotation = rotationSlider.getValueInt();
-                updateClientBlock();
-            }
-        };
+        rotationSlider.setValue(rotation);
+        rotationSlider.onSlider();
     }
     private double getModifier(Player.Hand hand){
         return hand == Player.Hand.PRIMARY ? 1.0 : 0.1;


### PR DESCRIPTION
This PR resolves crashing when using Manipulator's `rotation` setting
Besides, it adds `gradle.properties` to specify min heap memory size and change main class's method for accessing MC version to UMC API